### PR TITLE
Add Chinese topic-radar report generation and OpenAI/LLM provider config

### DIFF
--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -36,8 +36,12 @@ jobs:
       - name: Run daily digest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LLM_PROVIDER: ${{ secrets.LLM_PROVIDER }}
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
+          OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           PRODUCTHUNT_TOKEN: ${{ secrets.PRODUCTHUNT_TOKEN }}
           DIGEST_REPO: ${{ github.repository }}
@@ -87,4 +91,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DIGEST_REPO: ${{ github.repository }}
         run: pnpm close-stale
-

--- a/README.zh.md
+++ b/README.zh.md
@@ -19,6 +19,16 @@
 | [Lobste.rs](https://lobste.rs) | JSON API | 7 天内 AI/ML 标签内容 |
 | [Anthropic](https://anthropic.com) + [OpenAI](https://openai.com) | Sitemap | 通过 `lastmod` 差异检测新文章 |
 
+### 中文平台可发布选题雷达（MVP）
+
+在保留原有技术日报输出的同时，项目会额外基于 `Hacker News + GitHub Trending + Product Hunt + Dev.to` 生成中文选题池（结构化 JSON + Markdown）。用于辅助内容创作，不会自动发布到任何平台。
+
+- 输出文件：
+  - `digests/YYYY-MM-DD/topic-radar.json`（机器可读，字段含标题、平台、变现角度、评分等）
+  - `digests/YYYY-MM-DD/topic-radar.md`（人工阅读版，《今日中文平台可发布选题池》）
+- 若某个源无数据会自动跳过，不影响主流程。
+- `PRODUCTHUNT_TOKEN` 未配置时，会跳过 Product Hunt 源，不影响其它数据源和选题雷达生成。
+
 ## Web UI
 
 **[https://duanyytop.github.io/agents-radar](https://duanyytop.github.io/agents-radar)**
@@ -223,11 +233,13 @@ openclaw_peers:
 | `ANTHROPIC_API_KEY` | Anthropic 时 | API 密钥，兼容 Anthropic 和 Kimi Code |
 | `ANTHROPIC_BASE_URL` | 可选 | API 地址覆盖。使用 Kimi Code 时设置为 `https://api.kimi.com/coding/`，使用 Anthropic 时留空 |
 | `OPENAI_API_KEY` | OpenAI 时 | OpenAI API 密钥 |
-| `OPENAI_BASE_URL` | 可选 | OpenAI 端点覆盖 |
+| `OPENAI_BASE_URL` | 可选 | OpenAI 端点覆盖（如 302.AI：`https://api.302.ai/v1`） |
+| `OPENAI_MODEL` | 可选 | OpenAI 模型名覆盖（如 302.AI：`deepseek-v4-flash`） |
 | `OPENROUTER_API_KEY` | OpenRouter 时 | OpenRouter API 密钥 |
 | `TELEGRAM_BOT_TOKEN` | 可选 | Telegram bot token，从 [@BotFather](https://t.me/BotFather) 获取。设置后每次 digest 完成自动推送通知 |
 | `TELEGRAM_CHAT_ID` | 可选 | 接收通知的 Telegram 频道 / 群组 / 用户 ID |
 | `FEISHU_WEBHOOK_URLS` | 可选 | 飞书自定义机器人 Webhook URL，多个用英文逗号分隔。设置后每次 digest 完成自动推送卡片通知到所有群 |
+| `PRODUCTHUNT_TOKEN` | 可选 | Product Hunt API token。用于补充中文选题雷达来源；未配置时仅跳过 Product Hunt 数据源 |
 
 > `GITHUB_TOKEN` 由 GitHub Actions 自动提供，无需手动添加。使用 `github-copilot` 作为 Provider 时，同一 `GITHUB_TOKEN` 也用于 LLM 调用。
 
@@ -260,6 +272,19 @@ openclaw_peers:
 
 可通过 `ANTHROPIC_MODEL`、`OPENAI_MODEL`、`GITHUB_COPILOT_MODEL` 或 `OPENROUTER_MODEL` 分别覆盖默认模型名称。
 
+### 使用 302.AI（OpenAI-compatible API）
+
+如果你使用 302.AI，只需沿用 `openai` provider，并在 GitHub Secrets 中配置：
+
+```bash
+LLM_PROVIDER=openai
+OPENAI_API_KEY=<你的 302.AI API Key>
+OPENAI_BASE_URL=https://api.302.ai/v1
+OPENAI_MODEL=deepseek-v4-flash
+```
+
+> 302.AI 是 OpenAI-compatible 接口，无需改代码；保留 Anthropic 配置不受影响。
+
 Provider 抽象层位于 `src/providers/`，每个供应商对应独立文件并实现 `LlmProvider` 接口。新增供应商只需创建新文件并在工厂函数中注册。
 
 ## 本地运行
@@ -275,6 +300,8 @@ export ANTHROPIC_API_KEY=sk-ant-xxxxxxxx
 # 方式 B: OpenAI
 # export LLM_PROVIDER=openai
 # export OPENAI_API_KEY=sk-xxxxxxxx
+# export OPENAI_BASE_URL=https://api.302.ai/v1
+# export OPENAI_MODEL=deepseek-v4-flash
 
 # 方式 C: GitHub Copilot（使用 GITHUB_TOKEN）
 # export LLM_PROVIDER=github-copilot

--- a/src/generate-manifest.ts
+++ b/src/generate-manifest.ts
@@ -27,6 +27,7 @@ const REPORT_FILES = [
   "ai-hf-en",
   "ai-community",
   "ai-community-en",
+  "topic-radar",
   "ai-weekly",
   "ai-weekly-en",
   "ai-monthly",

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -163,6 +163,7 @@ export const REPORT_LABELS: Record<string, string> = {
   "ai-hf-en": "Hugging Face Trending Models Digest",
   "ai-community": "技术社区 AI 动态日报",
   "ai-community-en": "Tech Community AI Digest",
+  "topic-radar": "中文选题雷达",
   "ai-weekly": "AI 工具生态周报",
   "ai-weekly-en": "AI Tools Weekly Digest",
   "ai-monthly": "AI 工具生态月报",
@@ -179,6 +180,7 @@ export const NOTIFY_LABELS: Record<string, Record<Lang, string>> = {
   "ai-arxiv": t("ArXiv 研究", "ArXiv Research"),
   "ai-hf": t("HF 模型", "HF Models"),
   "ai-community": t("技术社区", "Tech Community"),
+  "topic-radar": t("中文选题雷达", "Chinese Topic Radar"),
   "ai-weekly": t("AI 工具生态周报", "AI Tools Weekly"),
   "ai-monthly": t("AI 工具生态月报", "AI Tools Monthly"),
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ import {
   saveArxivReport,
   saveHfReport,
   saveCommunityReport,
+  saveTopicRadarReport,
 } from "./report-savers.ts";
 import { loadWebState, fetchSiteContent, type WebFetchResult, type WebState } from "./web.ts";
 import { fetchTrendingData, type TrendingData } from "./trending.ts";
@@ -417,6 +418,7 @@ async function main(): Promise<void> {
     saveHfReport(hfData, utcStr, dateStr, digestRepo, autoGenFooter("en"), "en"),
     saveCommunityReport(devtoData, lobstersData, utcStr, dateStr, digestRepo, autoGenFooter("zh"), "zh"),
     saveCommunityReport(devtoData, lobstersData, utcStr, dateStr, digestRepo, autoGenFooter("en"), "en"),
+    saveTopicRadarReport(hnData, trendingData, phData, devtoData, utcStr, dateStr),
   ]);
 
   // 5. Generate highlights for Telegram notification

--- a/src/prompts-data.ts
+++ b/src/prompts-data.ts
@@ -14,6 +14,92 @@ import type { HfData } from "./hf.ts";
 import type { DevtoData } from "./devto.ts";
 import type { LobstersData } from "./lobsters.ts";
 import type { Lang } from "./i18n.ts";
+
+export function buildTopicRadarPrompt(input: {
+  dateStr: string;
+  hn: HnData;
+  trending: TrendingData;
+  ph: PhData;
+  devto: DevtoData;
+}): string {
+  const hnItems = input.hn.fetchSuccess
+    ? input.hn.stories
+        .slice(0, 20)
+        .map(
+          (s, i) =>
+            `${i + 1}. ${s.title}\n   url: ${s.url}\n   source: hn\n   points: ${s.points}, comments: ${s.comments}`,
+        )
+        .join("\n\n")
+    : "(no data)";
+
+  const trendingItems =
+    input.trending.trendingRepos.length || input.trending.searchRepos.length
+      ? [
+          ...input.trending.trendingRepos
+            .slice(0, 20)
+            .map(
+              (r, i) =>
+                `${i + 1}. ${r.fullName}\n   title: ${r.fullName}\n   url: ${r.url}\n   source: github-trending\n   stars: ${r.totalStars}, todayStars: ${r.todayStars}`,
+            ),
+          ...input.trending.searchRepos
+            .slice(0, 20)
+            .map(
+              (r, i) =>
+                `${i + 21}. ${r.fullName}\n   title: ${r.fullName}\n   url: ${r.url}\n   source: github-search\n   stars: ${r.stargazersCount}, topic: ${r.searchQuery}`,
+            ),
+        ].join("\n\n")
+      : "(no data)";
+
+  const phItems = input.ph.fetchSuccess
+    ? input.ph.products
+        .slice(0, 20)
+        .map(
+          (p, i) =>
+            `${i + 1}. ${p.name} — ${p.tagline}\n   url: ${p.website || p.url}\n   source: producthunt\n   votes: ${p.votesCount}, comments: ${p.commentsCount}`,
+        )
+        .join("\n\n")
+    : "(no data)";
+
+  const devtoItems = input.devto.fetchSuccess
+    ? input.devto.articles
+        .slice(0, 20)
+        .map(
+          (a, i) =>
+            `${i + 1}. ${a.title}\n   url: ${a.url}\n   source: devto\n   reactions: ${a.positiveReactionsCount}, comments: ${a.commentsCount}`,
+        )
+        .join("\n\n")
+    : "(no data)";
+
+  return `你是“中文平台可发布选题雷达”编辑。请基于以下候选数据，生成适合中文内容平台发布的选题池（仅中文输出）。\n
+日期：${input.dateStr}\n
+【Hacker News】\n${hnItems}\n
+【GitHub Trending / Search】\n${trendingItems}\n
+【Product Hunt】\n${phItems}\n
+【Dev.to】\n${devtoItems}\n
+输出要求（必须严格遵守）：
+1) 只返回合法 JSON，不要 markdown，不要解释，不要代码块。
+2) JSON 顶层格式：{"topics":[...]}。
+3) topics 每个元素必须包含以下字段：
+   - source
+   - original_title
+   - url
+   - title_cn
+   - summary_cn
+   - content_angle
+   - platform
+   - monetization_angle
+   - xiaohongshu_title
+   - cover_text
+   - video_hook
+   - score
+   - reason
+4) score 必须是 0-100 的整数。
+5) platform 用字符串数组，如 ["小红书","抖音"]。
+6) 不得编造输入中不存在的事实；若信息不足，可保守描述并在 reason 说明“信息有限”。
+7) 禁止夸大、禁止“保证收益/必爆/躺赚”等承诺性表达。
+8) 每条都要保留可追溯的原始链接 url。
+9) 去重后输出 8-20 条高质量选题，按 score 从高到低。`;
+}
 export function buildTrendingPrompt(data: TrendingData, dateStr: string, lang: Lang = "zh"): string {
   const trendingSection =
     data.trendingFetchSuccess && data.trendingRepos.length > 0

--- a/src/report-savers.ts
+++ b/src/report-savers.ts
@@ -21,6 +21,7 @@ import {
   buildArxivPrompt,
   buildHfPrompt,
   buildCommunityPrompt,
+  buildTopicRadarPrompt,
 } from "./prompts-data.ts";
 import { callLlm, saveFile, LLM_TOKENS_WEB } from "./report.ts";
 import { createGitHubIssue } from "./github.ts";
@@ -32,6 +33,110 @@ import type { ArxivData } from "./arxiv.ts";
 import type { HfData } from "./hf.ts";
 import type { DevtoData } from "./devto.ts";
 import type { LobstersData } from "./lobsters.ts";
+
+export interface TopicRadarItem {
+  source: string;
+  original_title: string;
+  url: string;
+  title_cn: string;
+  summary_cn: string;
+  content_angle: string;
+  platform: string[];
+  monetization_angle: string;
+  xiaohongshu_title: string;
+  cover_text: string;
+  video_hook: string;
+  score: number;
+  reason: string;
+}
+
+function parseTopicRadarJson(raw: string): TopicRadarItem[] {
+  const cleaned = raw
+    .replace(/```json?\n?/g, "")
+    .replace(/```/g, "")
+    .trim();
+  const parsed = JSON.parse(cleaned) as { topics?: unknown };
+  if (!parsed.topics || !Array.isArray(parsed.topics)) return [];
+  return parsed.topics
+    .map((t) => t as Partial<TopicRadarItem>)
+    .filter((t) => t.title_cn && t.url)
+    .map((t) => ({
+      source: String(t.source ?? "unknown"),
+      original_title: String(t.original_title ?? ""),
+      url: String(t.url ?? ""),
+      title_cn: String(t.title_cn ?? ""),
+      summary_cn: String(t.summary_cn ?? ""),
+      content_angle: String(t.content_angle ?? ""),
+      platform: Array.isArray(t.platform) ? t.platform.map(String) : [],
+      monetization_angle: String(t.monetization_angle ?? ""),
+      xiaohongshu_title: String(t.xiaohongshu_title ?? ""),
+      cover_text: String(t.cover_text ?? ""),
+      video_hook: String(t.video_hook ?? ""),
+      score: Math.max(0, Math.min(100, Math.trunc(Number(t.score ?? 0)))),
+      reason: String(t.reason ?? ""),
+    }))
+    .sort((a, b) => b.score - a.score);
+}
+
+export async function saveTopicRadarReport(
+  hnData: HnData,
+  trendingData: TrendingData,
+  phData: PhData,
+  devtoData: DevtoData,
+  utcStr: string,
+  dateStr: string,
+): Promise<void> {
+  const hasData =
+    hnData.fetchSuccess ||
+    trendingData.trendingRepos.length > 0 ||
+    trendingData.searchRepos.length > 0 ||
+    phData.fetchSuccess ||
+    devtoData.fetchSuccess;
+  if (!hasData) {
+    console.log("  [topic-radar] No source data available, skipping report.");
+    return;
+  }
+
+  console.log("  [topic-radar] Calling LLM for Chinese topic radar...");
+  try {
+    const raw = await callLlm(
+      buildTopicRadarPrompt({ dateStr, hn: hnData, trending: trendingData, ph: phData, devto: devtoData }),
+    );
+    const topics = parseTopicRadarJson(raw);
+    if (!topics.length) {
+      console.log("  [topic-radar] Empty topics after parsing, skipping save.");
+      return;
+    }
+
+    const jsonContent =
+      JSON.stringify({ generatedAt: `${utcStr} UTC`, date: dateStr, topics }, null, 2) + "\n";
+    console.log(`  Saved ${saveFile(jsonContent, dateStr, "topic-radar.json")}`);
+
+    const mdRows = topics
+      .map(
+        (t, i) =>
+          `## ${i + 1}. ${t.title_cn}\n\n` +
+          `- 评分：**${t.score}**\n` +
+          `- 来源：${t.source}\n` +
+          `- 原始标题：${t.original_title}\n` +
+          `- 原始链接：${t.url}\n` +
+          `- 中文摘要：${t.summary_cn}\n` +
+          `- 内容角度：${t.content_angle}\n` +
+          `- 适合平台：${t.platform.join(" / ")}\n` +
+          `- 变现方式：${t.monetization_angle}\n` +
+          `- 小红书标题：${t.xiaohongshu_title}\n` +
+          `- 封面文案：${t.cover_text}\n` +
+          `- 短视频钩子：${t.video_hook}\n` +
+          `- 评分理由：${t.reason}`,
+      )
+      .join("\n\n---\n\n");
+
+    const md = `# 今日中文平台可发布选题池 ${dateStr}\n\n> 生成时间: ${utcStr} UTC | 共 ${topics.length} 条\n\n---\n\n${mdRows}\n`;
+    console.log(`  Saved ${saveFile(md, dateStr, "topic-radar.md")}`);
+  } catch (err) {
+    console.error(`  [topic-radar] Report generation failed: ${err}`);
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Web report


### PR DESCRIPTION
### Motivation
- Add a new “中文选题雷达” feature that generates a structured topic pool for Chinese content platforms from existing sources (HN, GitHub Trending, Product Hunt, Dev.to). 
- Enable configuring OpenAI and generic LLM provider settings in the workflow and docs to support alternative OpenAI-compatible endpoints (e.g. 302.AI) and model overrides.

### Description
- Implemented a new topic radar pipeline: added `buildTopicRadarPrompt` in `src/prompts-data.ts` and `saveTopicRadarReport` (with `parseTopicRadarJson` and `TopicRadarItem`) in `src/report-savers.ts` to call the LLM, parse JSON output, and write `digests/YYYY-MM-DD/topic-radar.json` and `topic-radar.md`.
- Integrated the report into the run flow by calling `saveTopicRadarReport` from `src/index.ts` and registering `topic-radar` in `src/generate-manifest.ts` and `src/i18n.ts` (labels and notification mapping).
- Updated CI workflow `.github/workflows/daily-digest.yml` to expose new secrets `LLM_PROVIDER`, `OPENAI_API_KEY`, `OPENAI_BASE_URL`, and `OPENAI_MODEL` to the job environment.
- Extended `README.zh.md` with documentation for the Chinese topic radar feature, guidance for using `openai` provider with OpenAI-compatible endpoints (302.AI), and new secret descriptions for `OPENAI_BASE_URL`, `OPENAI_MODEL`, and `PRODUCTHUNT_TOKEN` behavior.

### Testing
- No automated tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6acd4c7d08326878baba581900f84)